### PR TITLE
Clenaup Initialization Of Publisher

### DIFF
--- a/rtns/host.go
+++ b/rtns/host.go
@@ -43,12 +43,9 @@ func NewPublisher(ctx context.Context, dsPath string, pk ci.PrivKey, listenAddrs
 		pk:  pk,
 		ds:  ds,
 		ps:  ps,
+		ns:  namesys.NewNameSystem(dt, ds, 128),
 		ctx: ctx,
 	}, nil
-}
-
-func (p *Publisher) SetNameSys() {
-	p.ns = namesys.NewNameSystem(p.d, p.ds, 128)
 }
 
 // Close is used to close all service needed by our publisher

--- a/rtns/host_test.go
+++ b/rtns/host_test.go
@@ -31,7 +31,6 @@ func Test_New_Publisher(t *testing.T) {
 	pk1 := newPK(t)
 	pk2 := newPK(t)
 	publisher.Bootstrap(lp.DefaultBootstrapPeers())
-	publisher.SetNameSys()
 	if err := publisher.Publish(ctx, pk1, ipfsPath1); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Made no sense to require instantiating the namesys after initialization of the publisher